### PR TITLE
fix: remove console.log from pipeline worker

### DIFF
--- a/src/web-workers/pipeline.worker.ts
+++ b/src/web-workers/pipeline.worker.ts
@@ -8,7 +8,6 @@ import IOInput from './IOInput.js'
 
 registerWebworker(async function (input: RunPipelineInput | IOInput) {
   let pipelineModule = null
-  console.log('input', input)
   if (input.operation === 'runPipeline') {
     pipelineModule = await loadPipelineModule(input.pipelinePath, input.config.pipelinesUrl)
   } else if (input.operation === 'readImage') {


### PR DESCRIPTION
this unnecessary adds logging to the console and slows down the process when the dev tools are open